### PR TITLE
Use pg.js instead of pg

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "superagent" : "*",
         "cheerio" : "*",
         "terraformer-wkt-parser" : "*",
-        "pg" : "*"
+        "pg.js" : "*"
     },
     "engines" : {
         "node" : "latest",


### PR DESCRIPTION
Hello,

pg does not build correctly on some platforms and @brianc recommends to use pg.js instead (which is basically the same package but in pure JS).

Regards,
